### PR TITLE
Add CDF Workbench v0.3.0

### DIFF
--- a/plugins/cdf-workbench.yaml
+++ b/plugins/cdf-workbench.yaml
@@ -9,6 +9,9 @@ tags:
 - inspector
 - tools
 versions:
+- version: 0.3.0
+  sciqlop: '>=0.10'
+  pip: https://github.com/SciQLop/sciqlop-plugins/releases/download/cdf_workbench/v0.3.0/sciqlop_cdf_workbench-0.3.0-py3-none-any.whl
 - version: 0.2.0
   sciqlop: '>=0.10'
   pip: https://github.com/SciQLop/sciqlop-plugins/releases/download/cdf_workbench/v0.2.0/sciqlop_cdf_workbench-0.2.0-py3-none-any.whl


### PR DESCRIPTION
## Summary
- Add CDF Workbench plugin version 0.3.0 to the appstore registry
- Wheel: `sciqlop_cdf_workbench-0.3.0-py3-none-any.whl`

## Changes in v0.3.0
- Replace matplotlib preview with SciQLopPlots (native colormaps, sparklines)
- Fix spectrogram rendering (full 2D DEPEND_1, descending energy channel flip)
- Fix NaN fill value detection in quality analysis
- Add dimension tags (0D/1D/2D) in variable tree
- Improved shutdown cleanup and timer leak fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)