### PR TITLE
fix: reorder CDF Workbench versions so latest is last

### DIFF
--- a/plugins/cdf-workbench.yaml
+++ b/plugins/cdf-workbench.yaml
@@ -9,9 +9,9 @@ tags:
 - inspector
 - tools
 versions:
-- version: 0.3.0
-  sciqlop: '>=0.10'
-  pip: https://github.com/SciQLop/sciqlop-plugins/releases/download/cdf_workbench/v0.3.0/sciqlop_cdf_workbench-0.3.0-py3-none-any.whl
 - version: 0.2.0
   sciqlop: '>=0.10'
   pip: https://github.com/SciQLop/sciqlop-plugins/releases/download/cdf_workbench/v0.2.0/sciqlop_cdf_workbench-0.2.0-py3-none-any.whl
+- version: 0.3.0
+  sciqlop: '>=0.10'
+  pip: https://github.com/SciQLop/sciqlop-plugins/releases/download/cdf_workbench/v0.3.0/sciqlop_cdf_workbench-0.3.0-py3-none-any.whl


### PR DESCRIPTION
## Summary
- Reorder versions in `cdf-workbench.yaml` so entries are chronological (oldest first, latest last)

## Test plan
- [ ] Verify `build_index.py` still generates the correct site with the reordered versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)